### PR TITLE
fix: improve client types

### DIFF
--- a/src/lib/stealthClient/createStealthClient.ts
+++ b/src/lib/stealthClient/createStealthClient.ts
@@ -1,6 +1,6 @@
 import { createPublicClient, http, type PublicClient } from 'viem';
 import { getChain } from '../helpers/chains';
-import { getAnnouncements, actions as stealthActions } from '../actions';
+import { actions as stealthActions } from '../actions';
 import {
   PublicClientRequiredError,
   type ClientParams,

--- a/src/lib/stealthClient/createStealthClient.ts
+++ b/src/lib/stealthClient/createStealthClient.ts
@@ -1,6 +1,6 @@
 import { createPublicClient, http, type PublicClient } from 'viem';
 import { getChain } from '../helpers/chains';
-import { actions as stealthActions } from '../actions';
+import { getAnnouncements, actions as stealthActions } from '../actions';
 import {
   PublicClientRequiredError,
   type ClientParams,
@@ -67,26 +67,33 @@ function createStealthClient({
 }
 
 const handleViemPublicClient = (clientParams?: ClientParams): PublicClient => {
-  let publicClient = clientParams?.publicClient;
-
-  if (publicClient) {
-    return publicClient;
-  }
-
-  if (!clientParams?.chainId || !clientParams?.rpcUrl) {
+  if (!clientParams) {
     throw new PublicClientRequiredError(
-      'clientParams chainId and rpcUrl are required'
+      'publicClient or chainId and rpcUrl must be provided'
     );
   }
 
-  try {
-    return createPublicClient({
-      chain: getChain(clientParams.chainId),
-      transport: http(clientParams.rpcUrl),
-    });
-  } catch (error) {
-    throw new PublicClientRequiredError('public client could not be created.');
+  if ('publicClient' in clientParams) {
+    return clientParams.publicClient;
   }
+
+  // Type guard for the 'chainId' and 'rpcUrl' properties
+  if ('chainId' in clientParams && 'rpcUrl' in clientParams) {
+    try {
+      return createPublicClient({
+        chain: getChain(clientParams.chainId),
+        transport: http(clientParams.rpcUrl),
+      });
+    } catch (error) {
+      throw new PublicClientRequiredError(
+        'public client could not be created.'
+      );
+    }
+  }
+
+  throw new PublicClientRequiredError(
+    'Either publicClient or both chainId and rpcUrl must be provided'
+  );
 };
 
 export { createStealthClient, handleViemPublicClient };

--- a/src/lib/stealthClient/types.ts
+++ b/src/lib/stealthClient/types.ts
@@ -10,38 +10,49 @@ import type {
   WatchAnnouncementsForUserReturnType,
 } from '../actions/';
 
-export type ClientParams = {
-  chainId?: VALID_CHAIN_IDS;
-  publicClient?: PublicClient;
-  rpcUrl?: string;
-};
+export type ClientParams =
+  | {
+      publicClient: PublicClient;
+    }
+  | {
+      chainId: VALID_CHAIN_IDS;
+      rpcUrl: string;
+    };
 
 export type StealthClientInitParams = {
   chainId: VALID_CHAIN_IDS;
   rpcUrl: string;
 };
 
-export type StealthClientReturnType = InitializedStealthActions;
+export type StealthClientReturnType = StealthActions;
 
 export type StealthActions = {
-  getAnnouncements: (
-    params: GetAnnouncementsParams
-  ) => Promise<GetAnnouncementsReturnType>;
-  getStealthMetaAddress: (
-    params: GetStealthMetaAddressParams
-  ) => Promise<GetStealthMetaAddressReturnType>;
-  getAnnouncementsForUser: (
-    params: GetAnnouncementsForUserParams
-  ) => Promise<GetAnnouncementsReturnType>;
-  watchAnnouncementsForUser: <T>(
-    params: WatchAnnouncementsForUserParams<T>
-  ) => Promise<WatchAnnouncementsForUserReturnType>;
-};
-
-export type InitializedStealthActions = {
-  [K in keyof StealthActions]: (
-    params: Parameters<StealthActions[K]>[0]
-  ) => ReturnType<StealthActions[K]>;
+  getAnnouncements: ({
+    ERC5564Address,
+    args,
+    fromBlock,
+    toBlock,
+  }: GetAnnouncementsParams) => Promise<GetAnnouncementsReturnType>;
+  getStealthMetaAddress: ({
+    ERC6538Address,
+    registrant,
+    schemeId,
+  }: GetStealthMetaAddressParams) => Promise<GetStealthMetaAddressReturnType>;
+  getAnnouncementsForUser: ({
+    announcements,
+    spendingPublicKey,
+    viewingPrivateKey,
+    excludeList,
+    includeList,
+  }: GetAnnouncementsForUserParams) => Promise<GetAnnouncementsReturnType>;
+  watchAnnouncementsForUser: <T>({
+    ERC5564Address,
+    args,
+    handleLogsForUser,
+    spendingPublicKey,
+    viewingPrivateKey,
+    pollOptions,
+  }: WatchAnnouncementsForUserParams<T>) => Promise<WatchAnnouncementsForUserReturnType>;
 };
 
 export class PublicClientRequiredError extends Error {


### PR DESCRIPTION
makes the types on the stealth client more verbose, while hiding the `clientParams`, since they are optional/unnecessary when the `stealthClient` is being used (instead of just using the func directly).