### PR TITLE
fix: contract address usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ console.log(
 
 ```ts
 import {
-  ERC5564_CONTRACT,
+  ERC5564_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient,
 } from "@scopelift/stealth-address-sdk";
@@ -141,8 +141,8 @@ const caller = "0xYourCallingContractAddress";
 const schemeId = BigInt(VALID_SCHEME_ID.SCHEME_ID_1);
 
 // The contract address of the ERC5564Announcer on your target blockchain
-// You can use the provided ERC5564_CONTRACT enum to get the singleton contract address for a valid chain ID
-const ERC5564Address = ERC5564_CONTRACT.SEPOLIA; // only for Sepolia for now
+// You can use the provided ERC5564_CONTRACT_ADDRESS get the singleton contract address for a valid chain ID
+const ERC5564Address = ERC5564_CONTRACT_ADDRESS;
 
 async function fetchAnnouncementsForUser() {
   // Example call to getAnnouncements action on the stealth client to get all potential announcements

--- a/examples/getAnnouncements/index.ts
+++ b/examples/getAnnouncements/index.ts
@@ -1,5 +1,5 @@
 import {
-  ERC5564_CONTRACT,
+  ERC5564_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient,
   getAnnouncements
@@ -24,8 +24,8 @@ const stealthAddress = '0xYourStealthAddress';
 const schemeId = BigInt(VALID_SCHEME_ID.SCHEME_ID_1);
 
 // The contract address of the ERC5564Announcer on your target blockchain
-// You can use the provided ERC5564_CONTRACT enum to get the singleton contract address for a valid chain ID
-const ERC5564Address = ERC5564_CONTRACT.SEPOLIA; // only for Sepolia for now
+// You can use the provided ERC5564_CONTRACT_ADDRESS get the singleton contract address for a valid chain ID
+const ERC5564Address = ERC5564_CONTRACT_ADDRESS;
 
 async function fetchAnnouncements() {
   if (!rpcUrl) throw new Error('Missing RPC_URL environment variable');

--- a/examples/getAnnouncementsForUser/index.ts
+++ b/examples/getAnnouncementsForUser/index.ts
@@ -1,5 +1,5 @@
 import {
-  ERC5564_CONTRACT,
+  ERC5564_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient
 } from '@scopelift/stealth-address-sdk';
@@ -20,8 +20,8 @@ const caller = '0xYourCallingContractAddress';
 const schemeId = BigInt(VALID_SCHEME_ID.SCHEME_ID_1);
 
 // The contract address of the ERC5564Announcer on your target blockchain
-// You can use the provided ERC5564_CONTRACT enum to get the singleton contract address for a valid chain ID
-const ERC5564Address = ERC5564_CONTRACT.SEPOLIA; // only for Sepolia for now
+// You can use the provided ERC5564_CONTRACT_ADDRESS get the singleton contract address for a valid chain ID
+const ERC5564Address = ERC5564_CONTRACT_ADDRESS;
 
 // Example keys for the user
 // These don't need to be from environment variables

--- a/examples/getStealthMetaAddress/index.ts
+++ b/examples/getStealthMetaAddress/index.ts
@@ -1,5 +1,5 @@
 import {
-  ERC6538_CONTRACT,
+  ERC6538_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient,
   getStealthMetaAddress
@@ -13,8 +13,7 @@ if (!rpcUrl) throw new Error('Missing RPC_URL environment variable');
 // Initialize the stealth client
 const stealthClient = createStealthClient({ chainId, rpcUrl });
 
-// Example getting the singleton registry contract address for Sepolia
-const ERC6538Address = ERC6538_CONTRACT.SEPOLIA;
+const ERC6538Address = ERC6538_CONTRACT_ADDRESS;
 
 // Example registrant
 const registrant = '0xYourRegistrantAddress'; // can also be an ens name

--- a/examples/prepareAnnounce/index.tsx
+++ b/examples/prepareAnnounce/index.tsx
@@ -5,7 +5,7 @@ import { sepolia } from 'viem/chains';
 import 'viem/window';
 
 import {
-  ERC5564_CONTRACT,
+  ERC5564_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient,
   generateStealthAddress
@@ -64,7 +64,7 @@ const Example = () => {
     // Prepare the announce payload
     const preparedPayload = await stealthClient.prepareAnnounce({
       account,
-      ERC5564Address: ERC5564_CONTRACT.SEPOLIA,
+      ERC5564Address: ERC5564_CONTRACT_ADDRESS,
       args: {
         schemeId: VALID_SCHEME_ID.SCHEME_ID_1,
         stealthAddress,

--- a/examples/prepareRegisterKeys/index.tsx
+++ b/examples/prepareRegisterKeys/index.tsx
@@ -5,7 +5,7 @@ import { sepolia } from 'viem/chains';
 import 'viem/window';
 
 import {
-  ERC6538_CONTRACT,
+  ERC6538_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient,
   parseStealthMetaAddressURI
@@ -62,7 +62,7 @@ const Example = () => {
     // Prepare the registerKeys payload
     const preparedPayload = await stealthClient.prepareRegisterKeys({
       account,
-      ERC6538Address: ERC6538_CONTRACT.SEPOLIA,
+      ERC6538Address: ERC6538_CONTRACT_ADDRESS,
       schemeId,
       stealthMetaAddress: stealthMetaAddressToRegister
     });

--- a/examples/prepareRegisterKeysOnBehalf/index.tsx
+++ b/examples/prepareRegisterKeysOnBehalf/index.tsx
@@ -5,7 +5,7 @@ import { sepolia } from 'viem/chains';
 import 'viem/window';
 
 import {
-  ERC6538_CONTRACT,
+  ERC6538_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient,
   parseStealthMetaAddressURI
@@ -62,7 +62,7 @@ const Example = () => {
     // Prepare the registerKeys payload
     const preparedPayload = await stealthClient.prepareRegisterKeysOnBehalf({
       account, // Your wallet address
-      ERC6538Address: ERC6538_CONTRACT.SEPOLIA,
+      ERC6538Address: ERC6538_CONTRACT_ADDRESS,
       args: {
         registrant: '0x', // Add the registrant address here
         schemeId,

--- a/examples/watchAnnouncementsForUser/index.ts
+++ b/examples/watchAnnouncementsForUser/index.ts
@@ -1,5 +1,5 @@
 import {
-  ERC5564_CONTRACT,
+  ERC5564_CONTRACT_ADDRESS,
   VALID_SCHEME_ID,
   createStealthClient
 } from '@scopelift/stealth-address-sdk';
@@ -14,8 +14,8 @@ const spendingPublicKey = '0xUserSpendingPublicKey';
 const viewingPrivateKey = '0xUserViewingPrivateKey';
 
 // The contract address of the ERC5564Announcer on your target blockchain
-// You can use the provided ERC5564_CONTRACT enum to get the singleton contract address for a valid chain ID
-const ERC5564Address = ERC5564_CONTRACT.SEPOLIA;
+// You can use the provided ERC5564_CONTRACT_ADDRESS get the singleton contract address for a valid chain ID
+const ERC5564Address = ERC5564_CONTRACT_ADDRESS;
 
 // Initialize the stealth client with your configuration
 const stealthClient = createStealthClient({ chainId, rpcUrl });

--- a/src/config/contractAddresses.ts
+++ b/src/config/contractAddresses.ts
@@ -1,9 +1,9 @@
 // Singleton announcer contract addresses
-export enum ERC5564_CONTRACT {
-  SEPOLIA = '0x55649E01B5Df198D18D95b5cc5051630cfD45564'
-}
+// This is the same for all chains
+export const ERC5564_CONTRACT_ADDRESS =
+  '0x55649E01B5Df198D18D95b5cc5051630cfD45564';
 
 // Singleton registry contract addresses
-export enum ERC6538_CONTRACT {
-  SEPOLIA = '0x6538E6bf4B0eBd30A8Ea093027Ac2422ce5d6538'
-}
+// This is the same for all chains
+export const ERC6538_CONTRACT_ADDRESS =
+  '0x6538E6bf4B0eBd30A8Ea093027Ac2422ce5d6538';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,2 +1,5 @@
-export { ERC5564_CONTRACT, ERC6538_CONTRACT } from './contractAddresses';
+export {
+  ERC5564_CONTRACT_ADDRESS,
+  ERC6538_CONTRACT_ADDRESS
+} from './contractAddresses';
 export { ERC5564_BYTECODE, ERC6538_BYTECODE } from './bytecode';

--- a/src/scripts/deployContract.ts
+++ b/src/scripts/deployContract.ts
@@ -1,9 +1,4 @@
-import type {
-  ERC5564AnnouncerAbi,
-  ERC5564_CONTRACT,
-  ERC6538RegistryAbi,
-  ERC6538_CONTRACT
-} from '..';
+import type { ERC5564AnnouncerAbi, ERC6538RegistryAbi } from '..';
 import setupTestWallet from '../lib/helpers/test/setupTestWallet';
 
 /**
@@ -16,12 +11,10 @@ import setupTestWallet from '../lib/helpers/test/setupTestWallet';
  * @returns {Promise<`0x${string}`>} - The address of the deployed contract
  */
 const deployContract = async ({
-  address,
   abi,
   bytecode,
   name
 }: {
-  address: ERC5564_CONTRACT | ERC6538_CONTRACT;
   abi: typeof ERC5564AnnouncerAbi | typeof ERC6538RegistryAbi;
   bytecode: `0x${string}`;
   name: string;

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,24 +1,20 @@
 import {
   ERC5564AnnouncerAbi,
   ERC5564_BYTECODE,
-  ERC5564_CONTRACT,
   ERC6538RegistryAbi,
-  ERC6538_BYTECODE,
-  ERC6538_CONTRACT
+  ERC6538_BYTECODE
 } from '..';
 import deployContract from './deployContract';
 
 const deployAllContracts = async () => {
   const { address: erc5564ContractAddress, deployBlock: erc5564DeployBlock } =
     await deployContract({
-      address: ERC5564_CONTRACT.SEPOLIA,
       abi: ERC5564AnnouncerAbi,
       name: 'ERC5564',
       bytecode: ERC5564_BYTECODE
     });
 
   const { address: erc6538ContractAddress } = await deployContract({
-    address: ERC6538_CONTRACT.SEPOLIA,
     abi: ERC6538RegistryAbi,
     name: 'ERC6538',
     bytecode: ERC6538_BYTECODE


### PR DESCRIPTION
Use one reference to each contract address for simplicity/ease-of-use.