### PR TITLE
feat: add Claude PR Assistant workflow

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -1,0 +1,36 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"


### PR DESCRIPTION
## Summary
Adds GitHub Actions workflow to enable `@claude` comments on PRs and issues.

## Features
- 🤖 Respond to `@claude` mentions in PR comments
- 🔍 Respond to `@claude` mentions in PR review comments  
- 📝 Respond to `@claude` mentions in issue comments
- ⚡ Uses official `anthropics/claude-code-action@beta`

## How to Use
Once merged, you can mention `@claude` in any:
- PR comment: `@claude please review this code for security issues`
- PR review comment: `@claude what do you think about this approach?` 
- Issue comment: `@claude can you help implement this feature?`

## Requirements
- ✅ `ANTHROPIC_API_KEY` secret is already configured in repository
- ✅ Proper permissions configured for reading repository content

The workflow will automatically trigger when Claude is mentioned and provide AI-powered assistance directly in GitHub\!

🤖 Generated with [Claude Code](https://claude.ai/code)