### PR TITLE
docs: release-process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+This repository is a TypeScript SDK for Ethereum stealth addresses implementing EIP-5564 and EIP-6538.
+
+Use [CLAUDE.md](CLAUDE.md) for:
+- development commands
+- architecture and code organization
+- testing and environment setup
+
+Use [RELEASING.md](RELEASING.md) for:
+- the current release process
+- versioning and changelog updates
+- publishing and tagging steps
+
+Agents working in this repository should follow the documented process in those files when making changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun tsc` - Run TypeScript compiler
 
 ### Publishing
+- Follow [RELEASING.md](RELEASING.md) for the current release procedure
 - `bun run publish` - Build and publish to npm
 
 ## Architecture Overview

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,22 @@
+# RELEASING.md
+
+## Release Checklist
+
+1. Decide whether a release is needed.
+2. Choose the next version: `patch`, `minor`, `major`, or next `beta`.
+3. Update [package.json](package.json).
+4. Update [CHANGELOG.md](CHANGELOG.md).
+5. Run:
+   - `bun run check`
+   - `bun run build`
+   - `bun test`
+6. Publish from the intended commit:
+   - stable: `bun run publish`
+   - beta: `bun run build && npm publish --tag beta`
+7. Create and push a tag like `v1.0.1` or `v1.0.0-beta.3`.
+
+## Notes
+
+- Release intent is maintainer-decided.
+- Stable releases should publish to the `latest` dist-tag.
+- Prereleases should publish to the `beta` dist-tag.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` as the repo-level orientation doc
- add `RELEASING.md` with the current manual release checklist
- update `CLAUDE.md` to point publishing guidance at `RELEASING.md`

## Why
- document the current release process without adding release automation
- give agents and maintainers a single place to look for release steps
- replace the broader Changesets automation proposal in #98 with a docs-only change

## Validation
- docs-only change
