### PR TITLE
chore: prep 1.0.0-beta.3 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,14 @@ jobs:
         run: |
           bun install
           bun run check
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Verify publish tarball
+        run: |
+          bun install
+          bun run build
+          npm pack --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,4 @@ jobs:
         run: npm pack --dry-run
 
       - name: Publish to npm
-        run: |
-          if [[ "${GITHUB_REF_NAME#v}" == *-* ]]; then
-            npm publish --provenance --access public --tag beta
-          else
-            npm publish --provenance --access public
-          fi
+        run: npm publish --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,21 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      - name: Validate release tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+            echo "Publish workflow must run from a tag ref; got $GITHUB_REF_TYPE:$GITHUB_REF_NAME"
+            exit 1
+          fi
+
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_VERSION)"
+            exit 1
+          fi
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,18 @@ jobs:
             exit 1
           fi
 
+      - name: Validate release tag points at latest main
+        run: |
+          git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+          TAG_COMMIT=$(git rev-parse HEAD)
+          MAIN_COMMIT=$(git rev-parse refs/remotes/origin/main)
+
+          if [ "$TAG_COMMIT" != "$MAIN_COMMIT" ]; then
+            echo "Tag commit ($TAG_COMMIT) is not the latest origin/main commit ($MAIN_COMMIT)"
+            exit 1
+          fi
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build package
+        run: bun run build
+
+      - name: Verify publish tarball
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        run: |
+          if [[ "${GITHUB_REF_NAME#v}" == *-* ]]; then
+            npm publish --provenance --access public --tag beta
+          else
+            npm publish --provenance --access public
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.3] - 2026-04-13
+
+### Added
+
+- ERC-5564 compliant metadata builder helpers for ETH, ERC-20, ERC-721, and custom payloads
+- `getAnnouncementsPageUsingSubgraph` for deterministic cursor-based subgraph pagination
+- Stealth client support and exported types for the new paginated subgraph action
+
+### Changed
+
+- Pin subgraph pagination to a snapshot block for consistent multi-page scans
+- Improve README coverage and JSDoc for the latest helper and subgraph APIs
+
+### Fixed
+
+- Harden metadata validation and related test coverage
+- Make stealth address checks insensitive to address casing
+
+## [1.0.0-beta.2] - 2024-11-21
+
+### Added
+
+- Improved announcement log fetching and subgraph handling
+- Additional valid chain support and a new transfer example
+
+### Fixed
+
+- Contract address handling fixes
+
 ## [1.0.0-beta.1] - 2024-07-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Publishing
 - Follow [RELEASING.md](RELEASING.md) for the current release procedure
 - `bun run publish` - Build and publish to npm
-- `bun run publish:beta` - Build and publish a prerelease to the `beta` dist-tag
 
 ## Architecture Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun run test-fork FILE=src/path/to/test.ts` - Run specific test against fork
 
 ### Building and Linting
-- `bun run build` - Apply Biome linting fixes and compile TypeScript
+- `bun run build` - Run Biome checks and compile TypeScript
 - `bun run check` - Run Biome linting checks without fixing
+- `bun run fix` - Apply Biome formatting and linting fixes
 - `biome check --apply .` - Apply Biome formatting and linting fixes
 - `bun tsc` - Run TypeScript compiler
 
 ### Publishing
+- Follow [RELEASING.md](RELEASING.md) for the current release procedure
 - `bun run publish` - Build and publish to npm
+- `bun run publish:beta` - Build and publish a prerelease to the `beta` dist-tag
 
 ## Architecture Overview
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,8 @@
    - `npm pack --dry-run`
 4. Open a PR to `main` and wait for CI to pass.
 5. Merge the PR.
-6. Publish by pushing a matching tag, for example `v1.0.0-beta.3`.
+6. Switch to the latest `main` after the merge and pull it locally.
+7. Publish by pushing a matching tag from that exact `main` commit, for example `v1.0.0-beta.3`.
 
 ## Publishing
 
@@ -18,6 +19,7 @@
 - npm publishing uses trusted publishing with GitHub OIDC; no long-lived npm token or PAT is required.
 - The publish job runs in the `npm-release` GitHub environment.
 - Release tags publish to npm with the default `latest` dist-tag.
+- The publish job fails unless the tag version matches `package.json` and the tag points at the latest `main` commit.
 
 ## Commands
 
@@ -25,6 +27,8 @@
 git switch -c release/1.0.0-beta.3
 git push -u origin release/1.0.0-beta.3
 
+git checkout main
+git pull
 git tag v1.0.0-beta.3
 git push origin v1.0.0-beta.3
 ```
@@ -32,5 +36,6 @@ git push origin v1.0.0-beta.3
 ## Notes
 
 - Keep the git tag and `package.json` version aligned.
+- Create the release tag from the latest `main`, not from the release branch tip.
 - Use `bun run fix` for local Biome autofixes when needed.
 - Real subgraph integration tests may depend on external subgraph availability.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,8 +17,7 @@
 - Publishing is handled by GitHub Actions via `.github/workflows/publish.yml`.
 - npm publishing uses trusted publishing with GitHub OIDC; no long-lived npm token or PAT is required.
 - The publish job runs in the `npm-release` GitHub environment.
-- Stable tags publish to npm with the default `latest` dist-tag.
-- Prerelease tags publish to npm with the `beta` dist-tag.
+- Release tags publish to npm with the default `latest` dist-tag.
 
 ## Commands
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,37 @@
+# RELEASING.md
+
+## Release Flow
+
+1. Create a release branch from `main`, for example `release/1.0.0-beta.3`.
+2. Update `package.json` and `CHANGELOG.md`.
+3. Run validation locally:
+   - `bun run build`
+   - `bun test`
+   - `npm pack --dry-run`
+4. Open a PR to `main` and wait for CI to pass.
+5. Merge the PR.
+6. Publish by pushing a matching tag, for example `v1.0.0-beta.3`.
+
+## Publishing
+
+- Publishing is handled by GitHub Actions via `.github/workflows/publish.yml`.
+- npm publishing uses trusted publishing with GitHub OIDC; no long-lived npm token or PAT is required.
+- The publish job runs in the `npm-release` GitHub environment.
+- Stable tags publish to npm with the default `latest` dist-tag.
+- Prerelease tags publish to npm with the `beta` dist-tag.
+
+## Commands
+
+```bash
+git switch -c release/1.0.0-beta.3
+git push -u origin release/1.0.0-beta.3
+
+git tag v1.0.0-beta.3
+git push origin v1.0.0-beta.3
+```
+
+## Notes
+
+- Keep the git tag and `package.json` version aligned.
+- Use `bun run fix` for local Biome autofixes when needed.
+- Real subgraph integration tests may depend on external subgraph availability.

--- a/package.json
+++ b/package.json
@@ -1,18 +1,36 @@
 {
   "name": "@scopelift/stealth-address-sdk",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "type": "module",
+  "files": [
+    "dist/config",
+    "dist/index.d.ts",
+    "dist/index.js",
+    "dist/lib/abi",
+    "dist/lib/actions",
+    "dist/lib/helpers/*.d.ts",
+    "dist/lib/helpers/*.js",
+    "dist/lib/index.d.ts",
+    "dist/lib/index.js",
+    "dist/lib/stealthClient",
+    "dist/utils",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "anvil-fork": "make anvil-fork",
     "test-fork": "make test-fork",
     "test": "bun test",
-    "build": "biome check --apply . && bun tsc",
+    "build": "bun run check && bun tsc",
     "watch": "bun test --watch src",
     "check": "biome check .",
-    "publish": "bun run build && npm publish"
+    "fix": "biome check --apply .",
+    "publish": "bun run build && npm publish --access public",
+    "publish:beta": "bun run build && npm publish --access public --tag beta"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "watch": "bun test --watch src",
     "check": "biome check .",
     "fix": "biome check --apply .",
-    "publish": "bun run build && npm publish --access public",
-    "publish:beta": "bun run build && npm publish --access public --tag beta"
+    "publish": "bun run build && npm publish --access public"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,12 @@
     "noUnusedLocals": true,
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "examples"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "examples",
+    "src/**/*.test.ts",
+    "src/**/test/**/*",
+    "src/test/**/*"
+  ],
 }


### PR DESCRIPTION
## Summary
- bump `@scopelift/stealth-address-sdk` to `1.0.0-beta.3`
- add release docs and fold in the useful docs work from #109
- add tag-driven trusted publishing via GitHub Actions and npm OIDC
- verify package contents in CI before release
- publish release tags to npm `latest`

## Validation
- `bun run build`
- `npm pack --dry-run`
- npm trusted publisher configured for `ScopeLift/stealth-address-sdk` + `publish.yml` + `npm-release`

## Notes
- supersedes #109
- real subgraph integration tests still depend on external subgraph availability
