### PR TITLE
fix: align npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Validate release tag matches package version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,8 @@
 - Publishing is handled by GitHub Actions via `.github/workflows/publish.yml`.
 - npm publishing uses trusted publishing with GitHub OIDC; no long-lived npm token or PAT is required.
 - The publish job runs in the `npm-release` GitHub environment.
+- `package.json` must include a `repository.url` that exactly matches `https://github.com/ScopeLift/stealth-address-sdk`.
+- The npm package's trusted publisher settings must exactly match `ScopeLift/stealth-address-sdk`, workflow `publish.yml`, and environment `npm-release`.
 - Release tags publish to npm with the default `latest` dist-tag.
 - The publish job fails unless the tag version matches `package.json` and the tag points at the latest `main` commit.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ScopeLift/stealth-address-sdk.git"
+  },
   "files": [
     "dist/config",
     "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add the missing `repository.url` metadata npm trusted publishing expects
- update the publish workflow to use Node 24 for current npm trusted publishing requirements
- document the exact npm trusted publisher prerequisites in `RELEASING.md`

## Why
The `v1.0.0-beta.3` publish workflow failed in `npm publish` with `E404` after build and tarball validation passed. The package already exists on npm, so this PR fixes the repo-side trusted publishing configuration gap.

## Validation
- confirmed `package.json` now exposes the exact GitHub repository URL
- attempted `bun run build`, but current `main` already fails on unrelated Biome `useExportType` findings in `src/lib/actions/index.ts`
