### PR TITLE
fix: publish prereleases to latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,4 +68,4 @@ jobs:
         run: npm pack --dry-run
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag latest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,7 +20,7 @@
 - The publish job runs in the `npm-release` GitHub environment.
 - `package.json` must include a `repository.url` that exactly matches `https://github.com/ScopeLift/stealth-address-sdk`.
 - The npm package's trusted publisher settings must exactly match `ScopeLift/stealth-address-sdk`, workflow `publish.yml`, and environment `npm-release`.
-- Release tags publish to npm with the default `latest` dist-tag.
+- Release tags publish to npm with an explicit `latest` dist-tag, which npm requires for prerelease versions.
 - The publish job fails unless the tag version matches `package.json` and the tag points at the latest `main` commit.
 
 ## Commands


### PR DESCRIPTION
## Summary
- publish prerelease versions with an explicit `--tag latest`
- update release docs to match npm's prerelease publish requirement

## Why
The second `v1.0.0-beta.3` publish attempt got past trusted publishing and failed in `npm publish` with:

```text
You must specify a tag using --tag when publishing a prerelease version.
```

This keeps the intended behavior from PR 110: prerelease release tags still publish to the `latest` dist-tag, but now in the explicit form npm 11 requires.

## Validation
- inspected the failed Actions run 24683172183 and confirmed the only remaining blocker was the missing `--tag`
