### PR TITLE
fix: remove recursive publish script

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,6 +17,7 @@
 
 - Publishing is handled by GitHub Actions via `.github/workflows/publish.yml`.
 - npm publishing uses trusted publishing with GitHub OIDC; no long-lived npm token or PAT is required.
+- Do not define an npm `publish` lifecycle script that calls `npm publish`; use a non-lifecycle script name such as `publish:manual` for manual local publishing helpers.
 - The publish job runs in the `npm-release` GitHub environment.
 - `package.json` must include a `repository.url` that exactly matches `https://github.com/ScopeLift/stealth-address-sdk`.
 - The npm package's trusted publisher settings must exactly match `ScopeLift/stealth-address-sdk`, workflow `publish.yml`, and environment `npm-release`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,7 @@
 
 - Publishing is handled by GitHub Actions via `.github/workflows/publish.yml`.
 - npm publishing uses trusted publishing with GitHub OIDC; no long-lived npm token or PAT is required.
-- Do not define an npm `publish` lifecycle script that calls `npm publish`; use a non-lifecycle script name such as `publish:manual` for manual local publishing helpers.
+- Do not define package publish scripts in `package.json`; publish to npm only through the GitHub Actions workflow.
 - The publish job runs in the `npm-release` GitHub environment.
 - `package.json` must include a `repository.url` that exactly matches `https://github.com/ScopeLift/stealth-address-sdk`.
 - The npm package's trusted publisher settings must exactly match `ScopeLift/stealth-address-sdk`, workflow `publish.yml`, and environment `npm-release`.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "watch": "bun test --watch src",
     "check": "biome check .",
     "fix": "biome check --apply .",
-    "publish": "bun run build && npm publish --access public"
+    "publish:manual": "bun run build && npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "build": "bun run check && bun tsc",
     "watch": "bun test --watch src",
     "check": "biome check .",
-    "fix": "biome check --apply .",
-    "publish:manual": "bun run build && npm publish --access public --tag latest"
+    "fix": "biome check --apply ."
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.4",


### PR DESCRIPTION
## Summary
- remove the npm `publish` lifecycle script that recursively called `npm publish`
- replace it with a non-lifecycle `publish:manual` helper for optional local use
- document the rule in `RELEASING.md`

## Why
The latest release workflow successfully published `@scopelift/stealth-address-sdk@1.0.0-beta.3`, then failed afterward because `npm publish` automatically ran the package's `publish` lifecycle script, which tried to run `npm publish` again.

## Validation
- confirmed `package.json` no longer defines a `publish` lifecycle script
- confirmed the manual helper still includes `--tag latest` for prerelease publishing
