### PR TITLE
fix: dedupe sender transaction lookups

### DIFF
--- a/src/lib/actions/getAnnouncementsForUser/getAnnouncementsForUser.test.ts
+++ b/src/lib/actions/getAnnouncementsForUser/getAnnouncementsForUser.test.ts
@@ -11,6 +11,7 @@ import setupTestWallet from '../../helpers/test/setupTestWallet';
 import type { SuperWalletClient } from '../../helpers/types';
 import type { StealthActions } from '../../stealthClient/types';
 import {
+  filterAnnouncementsForUserBatch,
   getTransactionFrom,
   processAnnouncement
 } from './getAnnouncementsForUser';
@@ -196,6 +197,33 @@ describe('getAnnouncementsForUser', () => {
 
     // Verify the function handles large data sets correctly
     expect(results).toHaveLength(PROCESS_LARGE_NUMBER_OF_ANNOUNCEMENTS_NUM);
+  });
+
+  test('deduplicates transaction lookups for repeated announcement hashes in one batch', async () => {
+    if (!account) throw new Error('No account found');
+
+    let transactionLookupCount = 0;
+    const duplicateAnnouncements = Array.from({ length: 5 }, () => ({
+      ...announcements[0]
+    }));
+    const publicClient = {
+      getTransaction: async () => {
+        transactionLookupCount += 1;
+        return { from: account.address };
+      }
+    };
+
+    const results = await filterAnnouncementsForUserBatch({
+      announcements: duplicateAnnouncements,
+      spendingPublicKey,
+      viewingPrivateKey,
+      includeList: new Set([account.address]),
+      excludeList: new Set([]),
+      publicClient
+    });
+
+    expect(results).toHaveLength(duplicateAnnouncements.length);
+    expect(transactionLookupCount).toBe(1);
   });
 
   test('throws TransactionHashRequiredError when transactionHash is null', async () => {

--- a/src/lib/actions/getAnnouncementsForUser/getAnnouncementsForUser.ts
+++ b/src/lib/actions/getAnnouncementsForUser/getAnnouncementsForUser.ts
@@ -7,6 +7,7 @@ import {
 import { handleViemPublicClient } from '../../stealthClient/createStealthClient';
 import type { AnnouncementLog } from '../getAnnouncements/types';
 import {
+  type AnnouncementTransactionFromCache,
   type AnnouncementTransactionLookupClient,
   type FilterAnnouncementsForUserBatchParams,
   FromValueNotFoundError,
@@ -50,12 +51,21 @@ export async function filterAnnouncementsForUserBatch({
   spendingPublicKey,
   viewingPrivateKey
 }: FilterAnnouncementsForUserBatchParams): Promise<GetAnnouncementsForUserReturnType> {
+  const transactionFromCache: AnnouncementTransactionFromCache | undefined =
+    announcementFiltersRequireTransactionLookup({
+      excludeList,
+      includeList
+    })
+      ? new Map()
+      : undefined;
+
   const processedAnnouncements = await Promise.allSettled(
     announcements.map(announcement =>
       processAnnouncement(announcement, {
         excludeList,
         includeList,
         publicClient,
+        transactionFromCache,
         spendingPublicKey,
         viewingPrivateKey
       })
@@ -131,6 +141,7 @@ export async function processAnnouncement(
     excludeList,
     includeList,
     publicClient,
+    transactionFromCache,
     spendingPublicKey,
     viewingPrivateKey
   }: ProcessAnnouncementParams
@@ -162,7 +173,8 @@ export async function processAnnouncement(
     hash,
     excludeList,
     includeList,
-    publicClient
+    publicClient,
+    transactionFromCache
   });
 
   if (!shouldInclude) return null;
@@ -186,12 +198,14 @@ async function shouldIncludeAnnouncement({
   hash,
   excludeList,
   includeList,
-  publicClient
+  publicClient,
+  transactionFromCache
 }: {
   hash: `0x${string}`;
   excludeList: Set<EthAddress>;
   includeList: Set<EthAddress>;
   publicClient?: AnnouncementTransactionLookupClient;
+  transactionFromCache?: AnnouncementTransactionFromCache;
 }): Promise<boolean> {
   if (excludeList.size === 0 && includeList.size === 0) return true; // No filters applied, include announcement
   if (!publicClient) {
@@ -200,7 +214,11 @@ async function shouldIncludeAnnouncement({
     );
   }
 
-  const from = await getTransactionFrom({ hash, publicClient });
+  const from = await getCachedTransactionFrom({
+    hash,
+    publicClient,
+    transactionFromCache
+  });
 
   if (excludeList.has(from)) return false; // Exclude if `from` is in excludeList
 
@@ -232,6 +250,29 @@ export async function getTransactionFrom({
   } catch (error) {
     throw new FromValueNotFoundError();
   }
+}
+
+async function getCachedTransactionFrom({
+  hash,
+  publicClient,
+  transactionFromCache
+}: {
+  publicClient: AnnouncementTransactionLookupClient;
+  hash: `0x${string}`;
+  transactionFromCache?: AnnouncementTransactionFromCache;
+}): Promise<EthAddress> {
+  if (!transactionFromCache) {
+    return getTransactionFrom({ hash, publicClient });
+  }
+
+  const cachedFrom = transactionFromCache.get(hash);
+  if (cachedFrom) {
+    return cachedFrom;
+  }
+
+  const from = getTransactionFrom({ hash, publicClient });
+  transactionFromCache.set(hash, from);
+  return from;
 }
 
 export default getAnnouncementsForUser;

--- a/src/lib/actions/getAnnouncementsForUser/types.ts
+++ b/src/lib/actions/getAnnouncementsForUser/types.ts
@@ -24,6 +24,11 @@ export type NormalizedAnnouncementAddressFilters = {
   includeList: Set<EthAddress>;
 };
 
+export type AnnouncementTransactionFromCache = Map<
+  `0x${string}`,
+  Promise<EthAddress>
+>;
+
 export type FilterAnnouncementsForUserBatchParams = {
   announcements: AnnouncementLog[];
   publicClient?: AnnouncementTransactionLookupClient;
@@ -33,6 +38,7 @@ export type FilterAnnouncementsForUserBatchParams = {
 
 export type ProcessAnnouncementParams = {
   publicClient?: AnnouncementTransactionLookupClient;
+  transactionFromCache?: AnnouncementTransactionFromCache;
   spendingPublicKey: `0x${string}`;
   viewingPrivateKey: `0x${string}`;
 } & NormalizedAnnouncementAddressFilters;


### PR DESCRIPTION
## Summary
- cache `txHash -> from` lookups within a filtered announcement batch
- share the batch cache through `getAnnouncementsForUser`, scan, and watch flows that use the same filtering helper
- add coverage for repeated announcement hashes only calling `getTransaction` once

## Verification
- `bun run build`
- `bun test src/lib/actions/getAnnouncementsForUser/getAnnouncementsForUser.test.ts`
- `bun test`

Refs #107